### PR TITLE
Fix buffer overflow at high sample rates

### DIFF
--- a/vbam/gba/Sound.cpp
+++ b/vbam/gba/Sound.cpp
@@ -306,8 +306,17 @@ void flush_samples(GBASystem *gba, GBA::Multi_Buffer * buffer)
 	// soundBufferLen should have a whole number of sample pairs
     assert( soundBufferLen % (2 * sizeof *gba->soundFinalWave) == 0 );
 
-	// number of samples in output buffer
-    blip_long const out_buf_size = soundBufferLen / sizeof *gba->soundFinalWave;
+	// number of samples in sound buffer
+    blip_long const snd_buf_size = soundBufferLen / sizeof *gba->soundFinalWave;
+
+        // maximum size of the output buffer
+    blip_long out_buf_size = sizeof gba->soundFinalWave / sizeof *gba->soundFinalWave;
+
+        // only read as many samples as the buffer allows, otherwise we
+        // get a segfault at high sample rates
+    if (out_buf_size > snd_buf_size) {
+      out_buf_size = snd_buf_size;
+    }
 
     while ( buffer->samples_avail() )
 	{


### PR DESCRIPTION
For regular low sample rates (e.g. 44100Hz, 48000Hz, etc.), the library works without any problems. For higher sample rates (e.g. 88200Hz, 96000Hz, etc.), the variable `out_buf_size`, which controls the maximum number of samples to be read into the `gba->soundFinalWave` buffer, exceeds the size of the buffer, causing an overflow (which can potentially also lead to a segfault). The `out_buf_size` is modified in this PR to be either:

 1) the number of samples in the sound buffer, as determined by `soundBufferLen` (the current behaviour); or
 2) the maximum number of samples the buffer can store

whichever is smaller. This prevents this overflow from occurring, and allows the library to be used for much higher samples rates (I have had success with rates as high as 384,000Hz, not that there is any need to go so high, without any obvious consequences of a buffer overflow occurring, i.e. no segfaults).